### PR TITLE
Fix numbered list first number and indent buttons

### DIFF
--- a/WordPad/MainPage.xaml
+++ b/WordPad/MainPage.xaml
@@ -846,7 +846,7 @@ VerticalAlignment="Top"
             <Grid x:Name="EditorContainer">
                 <ScrollViewer x:Name="RichTextScrollView"  HorizontalScrollBarVisibility="Visible" ZoomMode="Enabled" MinZoomFactor="0.5" MaxZoomFactor="3" VerticalAlignment="Top">
                     <Grid x:Name="EditorMandatoryPrintingGrid" Height="1116"   Width="816">
-                        <local:Editor x:Name="Editor"  Padding="45,45,45,45" SizeChanged="Editor_SizeChanged" Height="1116" Width="816" Style="{StaticResource MinEditStyleNeo}" SelectionChanged="editor_SelectionChanged" TextChanged="Editor_TextChanged" RenderTransformOrigin="0.5,0.5" IsSpellCheckEnabled="False" x:FieldModifier="public" VerticalAlignment="Top" HorizontalAlignment="Center">
+                        <local:Editor x:Name="Editor"  Padding="45,45,45,45" Loaded="Editor_Loaded" SizeChanged="Editor_SizeChanged" Height="1116" Width="816" Style="{StaticResource MinEditStyleNeo}" SelectionChanged="editor_SelectionChanged" TextChanged="Editor_TextChanged" RenderTransformOrigin="0.5,0.5" IsSpellCheckEnabled="False" x:FieldModifier="public" VerticalAlignment="Top" HorizontalAlignment="Center">
                         <RichEditBox.Resources>
                             <Storyboard x:Name="REBOpenAnimation">
                                 <DoubleAnimation Storyboard.TargetName="REBScale" Storyboard.TargetProperty="ScaleX" From="0.95" To="1.0" Duration="0:0:0.4">

--- a/WordPad/MainPage.xaml.cs
+++ b/WordPad/MainPage.xaml.cs
@@ -1908,5 +1908,12 @@ namespace RectifyPad
         {
 
         }
+
+        private void Editor_Loaded(object sender, RoutedEventArgs e)
+        {
+            var format = Editor.Document.GetDefaultParagraphFormat();
+            format.ListStart = 1;
+            Editor.Document.SetDefaultParagraphFormat(format);
+        }
     }
 }

--- a/WordPad/WordPadUI/Ribbon/ParagraphToolbar.xaml.cs
+++ b/WordPad/WordPadUI/Ribbon/ParagraphToolbar.xaml.cs
@@ -414,16 +414,16 @@ namespace WordPad.WordPadUI.Ribbon
         private void IndentationIncreaseRight_Click(object sender, RoutedEventArgs e)
         {
             Editor.Document.Selection.ParagraphFormat.SetIndents(Editor.Document.Selection.ParagraphFormat.FirstLineIndent,
-                                                                 Editor.Document.Selection.ParagraphFormat.LeftIndent + 10,
-                                                                 Editor.Document.Selection.ParagraphFormat.RightIndent - 10);
+                                                                 Editor.Document.Selection.ParagraphFormat.LeftIndent + 20,
+                                                                 Editor.Document.Selection.ParagraphFormat.RightIndent);
             Editor.Focus(FocusState.Keyboard);
         }
 
         private void IndentationIncreaseLeft_Click(object sender, RoutedEventArgs e)
         {
             Editor.Document.Selection.ParagraphFormat.SetIndents(Editor.Document.Selection.ParagraphFormat.FirstLineIndent,
-                                                                 Editor.Document.Selection.ParagraphFormat.LeftIndent - 10,
-                                                                 Editor.Document.Selection.ParagraphFormat.RightIndent + 10);
+                                                                 Math.Max(Editor.Document.Selection.ParagraphFormat.LeftIndent - 20, 0),
+                                                                 Editor.Document.Selection.ParagraphFormat.RightIndent);
             Editor.Focus(FocusState.Keyboard);
         }
 


### PR DESCRIPTION
This is a minor improvement over PR #16 , I didn't notice that numbered lists started from 0 rather than 1. Also, indent buttons now behave as most word processors (except the ruler still doesn't match). 